### PR TITLE
fix: package.json に dotenv を追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@google/genai": "^1.0.0",
     "better-sqlite3": "^11.0.0",
     "discord.js": "^14.16.0",
+    "dotenv": "^16.4.0",
     "googleapis": "^144.0.0",
     "node-cron": "^3.0.3"
   },


### PR DESCRIPTION
## Summary
- `src/config.ts` で `dotenv` を import しているが、`package.json` の dependencies に記載がなかった
- これにより、クリーンインストール後に `npm run register` が失敗する問題を修正
- `dotenv: ^16.4.0` を dependencies に追加

Closes #1

## Test plan
- [ ] `rm -rf node_modules && npm install` でクリーンインストール
- [ ] `npm run register` が正常に実行されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)